### PR TITLE
Update omniauth oauth2 180

### DIFF
--- a/example/config.ru
+++ b/example/config.ru
@@ -5,7 +5,7 @@ require './app.rb'
 use Rack::Session::Cookie, :secret => 'abc123'
 
 use OmniAuth::Builder do
-  provider :office365, ENV['OFFICE365_APP_ID'], ENV['OFFICE365_APP_SECRET'], :scope => 'https://outlook.office.com/mail.read'
+  provider :office365, ENV['OFFICE365_APP_ID'], ENV['OFFICE365_APP_SECRET'], :scope => 'user.read'
 end
 
 run Sinatra::Application

--- a/example/config.ru
+++ b/example/config.ru
@@ -8,4 +8,6 @@ use OmniAuth::Builder do
   provider :office365, ENV['OFFICE365_APP_ID'], ENV['OFFICE365_APP_SECRET'], :scope => 'user.read'
 end
 
+OmniAuth.config.allowed_request_methods = [:get, :post]
+
 run Sinatra::Application

--- a/lib/omniauth/strategies/office365.rb
+++ b/lib/omniauth/strategies/office365.rb
@@ -9,7 +9,7 @@ module OmniAuth
 
       # This is where you pass the options you would pass when
       # initializing your consumer from the OAuth gem.
-      option :client_options, :site => 'https://outlook.office.com/',
+      option :client_options, :site => 'https://graph.microsoft.com/',
                               :authorize_url => 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
                               :token_url => 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
 
@@ -23,8 +23,8 @@ module OmniAuth
       # https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema#schema-10-and-later
       info do
         {
-          :name => raw_info['DisplayName'],
-          :email => raw_info['EmailAddress'],
+          :name => raw_info['displayName'],
+          :email => raw_info['userPrincipalName'],
           :nickname => raw_info['Alias']
         }
       end
@@ -36,7 +36,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('api/v2.0/me').parsed
+        @raw_info ||= access_token.get('v1.0/me').parsed
       end
 
       private

--- a/lib/omniauth/strategies/office365.rb
+++ b/lib/omniauth/strategies/office365.rb
@@ -45,7 +45,7 @@ module OmniAuth
       #   we don't want the querystring appended to the callback_url
       # See https://github.com/omniauth/omniauth-oauth2/issues/81
       def callback_url
-        full_host + script_name + callback_path
+        options[:redirect_uri] || (full_host + script_name + callback_path)
       end
     end
   end

--- a/omniauth-office365.gemspec
+++ b/omniauth-office365.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[lib]
   gem.version       = OmniAuth::Office365::VERSION
 
-  gem.add_dependency 'omniauth-oauth2', '~> 1.6.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.7.1'
 
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
actualizar la dependencia 
omniauth-oauth2 de la versión 1.7.1 a la versión 1.8.0

Motivo: actualiazar en buk-webapp omniauth-google-oauth2